### PR TITLE
CI: remove deprecated output

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -14,7 +14,7 @@ jobs:
         name: Checkout
         uses: actions/checkout@v4
       - id: sha
-        run: echo "::set-output name=sha::$(git describe --always --tags --dirty)"
+        run: echo "sha=$(git describe --always --tags --dirty)" >> "$GITHUB_OUTPUT"
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
